### PR TITLE
applied rebranding to RejectionSamplers.jl

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,4 +1,4 @@
-name = "GPUEventGenerators"
+name = "RejectionSamplers"
 uuid = "90f62166-f53e-5083-ac0e-6e2bf74182ae"
 authors = [
   "Uwe Hernandez Acosta <u.hernandez@hzdr.de>",

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-# GPUEventGenerators.jl
+# RejectionSamplers.jl
 
-[![Main](https://img.shields.io/badge/docs-main-blue.svg)](https://qedjl-applications.pages.hzdr.de/GPUEventGenerators.jl)
-[![pipeline status](https://codebase.helmholtz.cloud/qedjl-applications/GPUEventGenerators.jl/badges/main/pipeline.svg)](https://codebase.helmholtz.cloud/qedjl-applications/GPUEventGenerators.jl/-/commits/main)
+[![Main](https://img.shields.io/badge/docs-main-blue.svg)](https://qedjl-project.github.io/RejectionSamplers.jl)
+[![pipeline status](https://codebase.helmholtz.cloud/qedjl-applications/RejectionSamplers.jl/badges/main/pipeline.svg)](https://codebase.helmholtz.cloud/qedjl-applications/RejectionSamplers.jl/-/commits/main)
 
-`GPUEventGenerators.jl` is a showcase project for Monte-Carlo Event Generation
+`RejectionSamplers.jl` is a showcase project for Monte-Carlo Event Generation
 on GPU. Its main goal is the investigation of end-to-end workflows to generate events for
 scattering processes.
 
@@ -11,19 +11,19 @@ scattering processes.
 
 ## Installation
 
-Since `GPUEventGenerators.jl` is not registered (and probably never will), you need to
+Since `RejectionSamplers.jl` is not registered (and probably never will), you need to
 clone the repository by youself:
 
 ### Clone with ssh (recommended)
 
 ```bash
-git clone git@codebase.helmholtz.cloud:qedjl-applications/GPUEventGenerators.jl.git
+git clone git@github.com:QEDjl-project/RejectionSamplers.jl.git
 ```
 
 ### Clone with https
 
 ```bash
-git clone https://codebase.helmholtz.cloud/qedjl-applications/GPUEventGenerators.jl.git
+git clone https://github.com/qedjl-project/RejectionSamplers.jl.git
 ```
 
 Within the root directory of the project, you can instantiate the project by entering the
@@ -39,7 +39,7 @@ pkg> instantiate
 To use the package in your Julia code, simply import it:
 
 ```julia-repl
-using GPUEventGenerators
+using RejectionSamplers
 ```
 
 For detailed documentation on available functions and examples, please refer to the

--- a/benchmarks/01_compton/Project.toml
+++ b/benchmarks/01_compton/Project.toml
@@ -1,7 +1,7 @@
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
-GPUEventGenerators = "90f62166-f53e-5083-ac0e-6e2bf74182ae"
+RejectionSamplers = "90f62166-f53e-5083-ac0e-6e2bf74182ae"
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 KernelAbstractions = "63c18a36-062a-441e-b654-da1e3ab1ce7c"
 Metal = "dde4c033-4e86-420c-a63e-0dd931031962"

--- a/benchmarks/01_compton/README.md
+++ b/benchmarks/01_compton/README.md
@@ -1,6 +1,6 @@
-# GPUEventGenerators Benchmarks
+# RejectionSamplers Benchmarks
 
-This directory contains a benchmark suite for **[GPUEventGenerators.jl](https://github.com/...)**, designed to measure the performance of event generation on multiple compute backends.
+This directory contains a benchmark suite for **[RejectionSamplers.jl](https://github.com/qedjl-project/RejectionSamplers.jl)**, designed to measure the performance of event generation on multiple compute backends.
 Supported backends include **CUDA, oneAPI, AMDGPU, Metal, and CPU** (OpenCL may be added in the future).
 
 ## Installation
@@ -8,7 +8,7 @@ Supported backends include **CUDA, oneAPI, AMDGPU, Metal, and CPU** (OpenCL may 
 Clone the repository and instantiate the benchmark environment:
 
 ```bash
-git clone https://codebase.helmholtz.cloud/qedjl-applications/GPUEventGenerators.jl.git
+git clone https://github.com/qedjl-project/RejectionSamplers.jl.git
 cd benchmarks/01_Compton
 julia --project=. init.jl
 ```

--- a/benchmarks/01_compton/benchmarks/full.jl
+++ b/benchmarks/01_compton/benchmarks/full.jl
@@ -26,7 +26,7 @@ for out_type in DTYPES
 
                 _group[batch_size][N] = @benchmarkable @sb(
                     begin
-                        GPUEventGenerators.generate_events(
+                        RejectionSamplers.generate_events(
                             $dist,
                             $proposal,
                             $max_value,

--- a/benchmarks/01_compton/benchmarks/hotloop.jl
+++ b/benchmarks/01_compton/benchmarks/hotloop.jl
@@ -26,7 +26,7 @@ for dtype in DTYPES
                 _group[batch_size][N] = @benchmarkable @sb(
                     begin
                         while running
-                            @inline GPUEventGenerators._generate_events!(
+                            @inline RejectionSamplers._generate_events!(
                                 $dist,
                                 $proposal,
                                 $max_value,

--- a/benchmarks/01_compton/benchmarks/proposal.jl
+++ b/benchmarks/01_compton/benchmarks/proposal.jl
@@ -21,11 +21,11 @@ for out_type in DTYPES
 
         _group[batch_size] = @benchmarkable @sb(
             begin
-                GPUEventGenerators.generate_proposals!($proposal, batch_buffer)
+                RejectionSamplers.generate_proposals!($proposal, batch_buffer)
             end
         ) setup = begin
             reclaim_mem()
-            batch_buffer = GPUEventGenerators._allocate_batch_buffer($BACKEND, $in_type, $out_type, $batch_size)
+            batch_buffer = RejectionSamplers._allocate_batch_buffer($BACKEND, $in_type, $out_type, $batch_size)
         end
     end
 end

--- a/benchmarks/01_compton/benchmarks/target.jl
+++ b/benchmarks/01_compton/benchmarks/target.jl
@@ -23,12 +23,12 @@ for out_type in DTYPES
 
         _group[batch_size] = @benchmarkable @sb(
             begin
-                GPUEventGenerators.evaluate_target!($target, batch_buffer)
+                RejectionSamplers.evaluate_target!($target, batch_buffer)
             end
         ) setup = begin
             reclaim_mem()
-            batch_buffer = GPUEventGenerators._allocate_batch_buffer($BACKEND, $in_type, $out_type, $batch_size)
-            GPUEventGenerators.generate_proposals!($proposal, batch_buffer)
+            batch_buffer = RejectionSamplers._allocate_batch_buffer($BACKEND, $in_type, $out_type, $batch_size)
+            RejectionSamplers.generate_proposals!($proposal, batch_buffer)
         end
     end
 end

--- a/benchmarks/01_compton/run.jl
+++ b/benchmarks/01_compton/run.jl
@@ -1,7 +1,7 @@
 # main structure adopted from AcceleratedKernels.jl/benchmark/runbenchmarks.jl
 
-using GPUEventGenerators
-using GPUEventGenerators.PerturbativeCompton
+using RejectionSamplers
+using RejectionSamplers.PerturbativeCompton
 using QEDcore
 using QEDprocesses
 

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,8 +1,10 @@
 [deps]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
-GPUEventGenerators = "90f62166-f53e-5083-ac0e-6e2bf74182ae"
 LiveServer = "16fef848-5104-11e9-1b77-fb7a48bbb589"
 QEDbase = "10e22c08-3ccb-4172-bfcf-7d7aa3d04d93"
+QEDcore = "35dc0263-cb5f-4c33-a114-1d7f54ab753e"
+QEDprocesses = "46de9c38-1bb3-4547-a1ec-da24d767fdad"
+RejectionSamplers = "90f62166-f53e-5083-ac0e-6e2bf74182ae"
 
 [compat]
 Documenter = "1"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,11 +1,11 @@
-using GPUEventGenerators
-using GPUEventGenerators.TestUtils
+using RejectionSamplers
+using RejectionSamplers.TestUtils
 using Documenter
 
 DocMeta.setdocmeta!(
-    GPUEventGenerators,
+    RejectionSamplers,
     :DocTestSetup,
-    :(using GPUEventGenerators);
+    :(using RejectionSamplers);
     recursive = true,
 )
 
@@ -16,17 +16,17 @@ const numbered_pages = [
 ]
 
 makedocs(;
-    modules = [GPUEventGenerators],
+    modules = [RejectionSamplers],
     authors = "Uwe Hernandez Acosta <u.hernandez@hzdr.de>, Simeon Ehrig, Anton Reinhard, René Widera",
-    repo = "https://codebase.helmholtz.cloud/qedjl-applications/GPUEventGenerators.jl/blob/{commit}{path}#{line}",
-    sitename = "GPUEventGenerators.jl",
+    repo = Documenter.Remotes.GitHub("QEDjl-project", "RejectionSamplers.jl"),
+    sitename = "RejectionSamplers.jl",
     format = Documenter.HTML(;
         prettyurls = get(ENV, "CI", "false") == "true",
-        repolink = "https://codebase.helmholtz.cloud/qedjl-applications/GPUEventGenerators.jl/blob/{commit}{path}#{line}",
-        canonical = "https://qedjl-applications.pages.hzdr.de/GPUEventGenerators.jl",
+        #repolink = "https://github.com/qedjl-project/RejectionSamplers.jl/blob/{commit}{path}#{line}",
+        canonical = "https://qedjl-project.github.io/RejectionSamplers.jl",
         assets = String[],
     ),
     pages = ["index.md"; numbered_pages],
 )
 
-deploydocs(; repo = "github.com/QEDjl-project/GPUEventGenerators.jl")
+deploydocs(; repo = "github.com/qedjl-project/RejectionSamplers.jl")

--- a/docs/src/90-contributing.md
+++ b/docs/src/90-contributing.md
@@ -10,7 +10,7 @@ Be polite and respectful, and follow the code of conduct.
 ## Bug reports and discussions
 
 If you think you found a bug, feel free to open an
-[issue](https://codebase.helmholtz.cloud/qedjl-applications/GPUEventGenerators.jl/-/issues). Focused
+[issue](https://github.com/qedjl-project/RejectionSamplers.jl/issues). Focused
 suggestions and requests can also be opened as issues. Before opening a pull request,
 start an issue or a discussion on the topic, please.
 

--- a/docs/src/91-developer.md
+++ b/docs/src/91-developer.md
@@ -22,7 +22,7 @@ clone the repository.
 3. Add this repo as a remote:
 
 ```bash
-git remote add upstream https://codebase.helmholtz.cloud/qedjl-applications/GPUEventGenerators.jl.git
+git remote add upstream https://github.com/qedjl-project/RejectionSamplers.jl.git
 ```
 
 This will ensure that you have two remotes in your git: `origin` and `upstream`. You will

--- a/docs/src/95-reference.md
+++ b/docs/src/95-reference.md
@@ -13,5 +13,5 @@ Pages = ["95-reference.md"]
 ```
 
 ```@autodocs
-Modules = [GPUEventGenerators,TestUtils]
+Modules = [RejectionSamplers,TestUtils]
 ```

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,7 +1,7 @@
 ```@meta
-CurrentModule = GPUEventGenerators
+CurrentModule = RejectionSamplers
 ```
 
-# GPUEventGenerators
+# RejectionSamplers
 
-Documentation for [GPUEventGenerators](https://github.com/QEDjl-project/GPUEventGenerators.jl).
+Documentation for [RejectionSamplers](https://github.com/qedjl-project/RejectionSamplers.jl).

--- a/examples/perturbative_compton/Project.toml
+++ b/examples/perturbative_compton/Project.toml
@@ -1,6 +1,6 @@
 [deps]
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
 CairoMakie = "13f3f980-e62b-5c42-98c6-ff1f3baf88f0"
-GPUEventGenerators = "90f62166-f53e-5083-ac0e-6e2bf74182ae"
+RejectionSamplers = "90f62166-f53e-5083-ac0e-6e2bf74182ae"
 KernelAbstractions = "63c18a36-062a-441e-b654-da1e3ab1ce7c"
 PairPlots = "43a3c2be-4208-490b-832a-a21dcd55d7da"

--- a/examples/perturbative_compton/README.md
+++ b/examples/perturbative_compton/README.md
@@ -17,13 +17,13 @@ the solid angle distribution of the scattering of a single photon off an electro
 Ensure you have cloned the repository containing this example.
 
 ```bash
-git clone git@codebase.helmholtz.cloud:qedjl-applications/GPUEventGenerators.jl.git
+git clone git@github.com/qedjl-project/RejectionSamplers.jl.git
 cd <repository-directory>/examples/perturbative_compton
 ```
 
 ### 2. Initialize the Example Environment
 
-Since `GPUEventGenerators.jl` is not registered Julia packages,
+Since `RejectionSamplers.jl` is not registered Julia packages,
 you need to initialize the environment manually. Run the following command inside the `examples/perturbative_compton` directory:
 
 ```bash
@@ -32,7 +32,7 @@ julia --project=. init.jl
 
 This script will:
 
-- Activate `GPUEventGenerators.jl` in the example environment.
+- Activate `RejectionSamplers.jl` in the example environment.
 - Install all other necessary dependencies.
 - Instantiate the example environment
 

--- a/examples/perturbative_compton/example.jl
+++ b/examples/perturbative_compton/example.jl
@@ -1,8 +1,8 @@
 using KernelAbstractions
 using BenchmarkTools
 using Random
-using GPUEventGenerators
-using GPUEventGenerators.PerturbativeCompton
+using RejectionSamplers
+using RejectionSamplers.PerturbativeCompton
 
 using CairoMakie
 using PairPlots
@@ -71,7 +71,7 @@ function run_example(
 
     # Generate events
     @info "Generate N = $N events with batch_size=$batch_size"
-    data = GPUEventGenerators.generate_events(
+    data = RejectionSamplers.generate_events(
         dist,
         proposal,
         max_value,

--- a/examples/truncated_gaussian/Project.toml
+++ b/examples/truncated_gaussian/Project.toml
@@ -2,7 +2,7 @@
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
 CairoMakie = "13f3f980-e62b-5c42-98c6-ff1f3baf88f0"
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
-GPUEventGenerators = "90f62166-f53e-5083-ac0e-6e2bf74182ae"
+RejectionSamplers = "90f62166-f53e-5083-ac0e-6e2bf74182ae"
 KernelAbstractions = "63c18a36-062a-441e-b654-da1e3ab1ce7c"
 PairPlots = "43a3c2be-4208-490b-832a-a21dcd55d7da"
 QuadGK = "1fd47b50-473d-5c70-9696-f719f8f3bcdc"

--- a/examples/truncated_gaussian/README.md
+++ b/examples/truncated_gaussian/README.md
@@ -17,13 +17,13 @@ a non-trivial extension of the Gaussian distribution confined to a specified int
 Ensure you have cloned the repository containing this example.
 
 ```bash
-git clone git@codebase.helmholtz.cloud:qedjl-applications/GPUEventGenerators.jl.git
+git clone git@github.com/qedjl-project/RejectionSamplers.jl.git
 cd <repository-directory>/example
 ```
 
 ### 2. Initialize the Example Environment
 
-Since `GPUEventGenerators.jl` is not a registered Julia package,
+Since `RejectionSamplers.jl` is not a registered Julia package,
 you need to initialize the environment manually. Run the following command inside the `examples/truncated_gaussian` directory:
 
 ```bash
@@ -32,7 +32,7 @@ julia --project=. init.jl
 
 This script will:
 
-- Activate `GPUEventGenerators.jl` in the example environment.
+- Activate `RejectionSamplers.jl` in the example environment.
 - Install all other necessary dependencies.
 - Instantiate the example environment
 

--- a/examples/truncated_gaussian/example1D.jl
+++ b/examples/truncated_gaussian/example1D.jl
@@ -7,8 +7,8 @@ using QuadGK
 
 const RNG = MersenneTwister(1234)
 
-using GPUEventGenerators
-using GPUEventGenerators.TruncatedGaussians
+using RejectionSamplers
+using RejectionSamplers.TruncatedGaussians
 
 using CairoMakie
 
@@ -40,9 +40,9 @@ function plot_samples(
     ax = Axis(f[1, 1], xlabel = "x", ylabel = "normalized event count")
     hist!(ax, samples, normalization = :pdf, bins = 100, color = :orange)
 
-    tot_weight, _ = quadgk(x -> GPUEventGenerators._compute(dist, x), extrema(dist)...)
+    tot_weight, _ = quadgk(x -> RejectionSamplers._compute(dist, x), extrema(dist)...)
     x = range(extrema(dist)..., 100)
-    vals = @. GPUEventGenerators._compute(dist, x) / tot_weight
+    vals = @. RejectionSamplers._compute(dist, x) / tot_weight
 
     lines!(ax, x, vals, linestyle = :dash, color = :black)
 
@@ -90,7 +90,7 @@ function run_example(
 
     ## number of samples to be generated
     @info "generate events"
-    data = GPUEventGenerators.generate_events(
+    data = RejectionSamplers.generate_events(
         dist,
         proposal,
         max_value,

--- a/examples/truncated_gaussian/exampleND.jl
+++ b/examples/truncated_gaussian/exampleND.jl
@@ -1,8 +1,8 @@
 using KernelAbstractions
 using BenchmarkTools
 using Random
-using GPUEventGenerators
-using GPUEventGenerators.TruncatedGaussians
+using RejectionSamplers
+using RejectionSamplers.TruncatedGaussians
 
 using CairoMakie
 using PairPlots
@@ -84,7 +84,7 @@ function run_example(
 
     # Generate events
     @info "Generate N = $N events with batch_size=$batch_size"
-    data = GPUEventGenerators.generate_events(
+    data = RejectionSamplers.generate_events(
         dist,
         proposal,
         max_value,

--- a/ext/AMDGPUTestExt.jl
+++ b/ext/AMDGPUTestExt.jl
@@ -1,10 +1,10 @@
 module AMDGPUTestExt
 
-using GPUEventGenerators
-using GPUEventGenerators.TestUtils
+using RejectionSamplers
+using RejectionSamplers.TestUtils
 using AMDGPU
 
-@inline function GPUEventGenerators.TestUtils.get_test_setup(backend::ROCBackend)
+@inline function RejectionSamplers.TestUtils.get_test_setup(backend::ROCBackend)
     return TestSetup(backend, (ROCVector,), (Float32, Float64))
 end
 

--- a/ext/CUDATestExt.jl
+++ b/ext/CUDATestExt.jl
@@ -1,10 +1,10 @@
 module CUDATestExt
 
-using GPUEventGenerators
-using GPUEventGenerators.TestUtils
+using RejectionSamplers
+using RejectionSamplers.TestUtils
 using CUDA
 
-@inline function GPUEventGenerators.TestUtils.get_test_setup(backend::CUDABackend)
+@inline function RejectionSamplers.TestUtils.get_test_setup(backend::CUDABackend)
     backends = (
         CUDABackend(),
         CUDABackend(prefer_blocks = true),

--- a/ext/MetalTestExt.jl
+++ b/ext/MetalTestExt.jl
@@ -1,10 +1,10 @@
 module MetalTestExt
 
-using GPUEventGenerators
-using GPUEventGenerators.TestUtils
+using RejectionSamplers
+using RejectionSamplers.TestUtils
 using Metal
 
-@inline function GPUEventGenerators.TestUtils.get_test_setup(backend::MetalBackend)
+@inline function RejectionSamplers.TestUtils.get_test_setup(backend::MetalBackend)
     return TestSetup(backend, (MtlVector,), (Float16, Float32))
 end
 

--- a/ext/PlotEx.jl
+++ b/ext/PlotEx.jl
@@ -2,11 +2,11 @@ module PlotEx
 
 using StatsPlots
 using QuadGK
-using GPUEventGenerators
+using RejectionSamplers
 
-function GPUEventGenerators.plot_compare(
+function RejectionSamplers.plot_compare(
         samples::AbstractVector,
-        dist::GPUEventGenerators.AbstractUnivariatTargetDistribution;
+        dist::RejectionSamplers.AbstractUnivariatTargetDistribution;
         kwargs...,
     )
     P = histogram(
@@ -20,11 +20,11 @@ function GPUEventGenerators.plot_compare(
         kwargs...,
     )
 
-    tot_weight, _ = quadgk(x -> GPUEventGenerators._compute(dist, x), extrema(dist)...)
+    tot_weight, _ = quadgk(x -> RejectionSamplers._compute(dist, x), extrema(dist)...)
     plot!(
         P,
         range(extrema(dist)...; length = 100),
-        x -> GPUEventGenerators._compute(dist, x) / tot_weight;
+        x -> RejectionSamplers._compute(dist, x) / tot_weight;
         label = "normalized target dist.",
         line = (2, :black, :dash),
         alpha = 0.5,

--- a/ext/oneAPITestExt.jl
+++ b/ext/oneAPITestExt.jl
@@ -1,10 +1,10 @@
 module oneAPITestExt
 
-using GPUEventGenerators
-using GPUEventGenerators.TestUtils
+using RejectionSamplers
+using RejectionSamplers.TestUtils
 using oneAPI
 
-@inline function GPUEventGenerators.TestUtils.get_test_setup(backend::oneAPIBackend)
+@inline function RejectionSamplers.TestUtils.get_test_setup(backend::oneAPIBackend)
 
     # check if f64 is supported
     if oneL0.module_properties(oneAPI.device()).fp64flags &

--- a/src/RejectionSamplers.jl
+++ b/src/RejectionSamplers.jl
@@ -1,4 +1,4 @@
-module GPUEventGenerators
+module RejectionSamplers
 
 # utils
 export filter_scan

--- a/src/examples/perturbative_compton.jl
+++ b/src/examples/perturbative_compton.jl
@@ -1,7 +1,7 @@
 module PerturbativeCompton
 
 
-using GPUEventGenerators
+using RejectionSamplers
 using QEDprocesses
 using QEDcore
 using StaticArrays
@@ -19,7 +19,7 @@ get_alpha(::Type{Float32}) = ALPHA32
 
 ### Klein-Nishina
 
-struct KleinNishinaDistribution{T} <: GPUEventGenerators.AbstractMultivariateTarget{2}
+struct KleinNishinaDistribution{T} <: RejectionSamplers.AbstractMultivariateTarget{2}
     omega::T
 
     function KleinNishinaDistribution(omega::T) where {T <: Real}
@@ -41,11 +41,11 @@ function _klein_nishina_formula(omega::T, cos_theta::T, phi::T) where {T <: Real
         (omp_over_om + inv(omp_over_om) - one(omega) + cos_theta^2)
 end
 
-function GPUEventGenerators.maximum_value(d::KleinNishinaDistribution{T}) where {T <: Real}
+function RejectionSamplers.maximum_value(d::KleinNishinaDistribution{T}) where {T <: Real}
     return _klein_nishina_formula(d.omega, one(T), zero(T))
 end
 
-function GPUEventGenerators._compute(
+function RejectionSamplers._compute(
         dist::KleinNishinaDistribution{T},
         cth_phi::SVector{2, T},
     ) where {T <: Real}
@@ -64,7 +64,7 @@ struct ComptonDistribution{
         C <: Compton,
         M <: AbstractModelDefinition,
         PSL <: AbstractOutPhaseSpaceLayout,
-    } <: GPUEventGenerators.AbstractMultivariateTarget{N}
+    } <: RejectionSamplers.AbstractMultivariateTarget{N}
     proc::C
     model::M
     psl::PSL
@@ -90,7 +90,7 @@ ComptonDistribution(
 ) = ComptonDistribution{Float64}(model, psl; spin_pol)
 
 
-function GPUEventGenerators._compute(
+function RejectionSamplers._compute(
         dist::ComptonDistribution{T, DOF},
         coords::SVector{DOF, T},
     ) where {DOF, T <: Real}

--- a/src/examples/scattering_process.jl
+++ b/src/examples/scattering_process.jl
@@ -2,7 +2,7 @@ module HardScattering
 
 export HardScatteringDistribution
 
-using GPUEventGenerators
+using RejectionSamplers
 using QEDbase
 
 struct HardScatteringDistribution{
@@ -10,7 +10,7 @@ struct HardScatteringDistribution{
         P <: AbstractProcessDefinition,
         M <: AbstractModelDefinition,
         PSL <: AbstractOutPhaseSpaceLayout,
-    } <: GPUEventGenerators.AbstractMultivariateTarget{DOF}
+    } <: RejectionSamplers.AbstractMultivariateTarget{DOF}
 
     proc::P
     model::M
@@ -35,9 +35,9 @@ struct HardScatteringDistribution{
 end
 
 # TODO: insert max-finder functionality instead (e.g. from QEDprobing.jl)
-function GPUEventGenerators.maximum_value(d::HardScatteringDistribution) end
+function RejectionSamplers.maximum_value(d::HardScatteringDistribution) end
 
-function GPUEventGenerators._compute(
+function RejectionSamplers._compute(
         dist::HardScatteringDistribution{DOF},
         coords::NTuple{DOF, T},
     ) where {DOF, T <: Real}

--- a/src/examples/truncated_gaussian.jl
+++ b/src/examples/truncated_gaussian.jl
@@ -6,7 +6,7 @@ using Random
 using QuadGK
 using StaticArrays
 
-using GPUEventGenerators
+using RejectionSamplers
 
 export TruncatedGaussian1D
 export TruncatedGaussian
@@ -14,7 +14,7 @@ export TruncatedGaussian
 # test target distribution
 
 struct TruncatedGaussian1D{T <: Real} <:
-    GPUEventGenerators.AbstractUnivariatTargetDistribution
+    RejectionSamplers.AbstractUnivariatTargetDistribution
     mu::T
     sig::T
     lower::T
@@ -38,13 +38,13 @@ Base.minimum(d::TruncatedGaussian1D) = d.lower
 Base.maximum(d::TruncatedGaussian1D) = d.upper
 is_in_domain(d::TruncatedGaussian1D, x) = d.lower <= x <= d.upper
 
-function GPUEventGenerators.maximum_value(d::TruncatedGaussian1D{T}) where {T}
+function RejectionSamplers.maximum_value(d::TruncatedGaussian1D{T}) where {T}
     crit_pt = min(max(d.mu, d.lower), d.upper)
     return _unsafe_compute(d, crit_pt)
 end
 
 _unsafe_compute(d::TruncatedGaussian1D, x) = normpdf(d.mu, d.sig, x)
-GPUEventGenerators._compute(d::TruncatedGaussian1D{T}, x) where {T} =
+RejectionSamplers._compute(d::TruncatedGaussian1D{T}, x) where {T} =
     is_in_domain(d, x) ? _unsafe_compute(d, x) : zero(T)
 
 
@@ -69,7 +69,7 @@ function _assert_correct_boundaries(
     return nothing
 end
 
-struct TruncatedGaussian{T <: Real, N} <: GPUEventGenerators.AbstractMultivariateTarget{N}
+struct TruncatedGaussian{T <: Real, N} <: RejectionSamplers.AbstractMultivariateTarget{N}
 
     mu::NTuple{N, T}
     sig::NTuple{N, T}
@@ -96,7 +96,7 @@ function is_in_domain(d::TruncatedGaussian{T, N}, x::SVector{N, T}) where {N, T}
 end
 
 
-function GPUEventGenerators.maximum_value(d::TruncatedGaussian{T, N}) where {T, N}
+function RejectionSamplers.maximum_value(d::TruncatedGaussian{T, N}) where {T, N}
     crit_pt = @. min(max(d.mu, d.lower), d.upper)
 
     return _unsafe_compute(d, crit_pt)
@@ -104,7 +104,7 @@ end
 
 _unsafe_compute(d::TruncatedGaussian{T, N}, x) where {N, T} =
     prod(ntuple(i -> normpdf(d.mu[i], d.sig[i], x[i]), N))
-GPUEventGenerators._compute(d::TruncatedGaussian{T}, x) where {T} =
+RejectionSamplers._compute(d::TruncatedGaussian{T}, x) where {T} =
     is_in_domain(d, x) ? _unsafe_compute(d, x) : zero(T)
 
 

--- a/src/mocks/Mocks.jl
+++ b/src/mocks/Mocks.jl
@@ -6,7 +6,7 @@ export MockTarget
 using Distributions
 using Random
 using StaticArrays
-using GPUEventGenerators
+using RejectionSamplers
 
 include("proposal.jl")
 include("target.jl")

--- a/src/mocks/proposal.jl
+++ b/src/mocks/proposal.jl
@@ -1,16 +1,16 @@
-struct MockProposal{T, D, TT, V} <: GPUEventGenerators.AbstractProposal{TT, V}
+struct MockProposal{T, D, TT, V} <: RejectionSamplers.AbstractProposal{TT, V}
 
     # scalar proposal
     MockProposal(::Type{T}) where {T <: Real} = new{T, 1, T, Distributions.Univariate}()
 
     # SVector proposal
-    MockProposal(::Type{TT}) where {N, T <: Real, TT <: SVector{N, T}} = new{T, N, TT, GPUEventGenerators.CoordinateVariate}()
+    MockProposal(::Type{TT}) where {N, T <: Real, TT <: SVector{N, T}} = new{T, N, TT, RejectionSamplers.CoordinateVariate}()
 
     # NTuple proposal
-    MockProposal(::Type{TT}) where {N, T <: Real, TT <: NTuple{N, T}} = new{T, N, TT, GPUEventGenerators.CoordinateVariate}()
+    MockProposal(::Type{TT}) where {N, T <: Real, TT <: NTuple{N, T}} = new{T, N, TT, RejectionSamplers.CoordinateVariate}()
 end
 
-GPUEventGenerators.degrees_of_freedom(::MockProposal{T, D, TT}) where {T, D, TT} = D
+RejectionSamplers.degrees_of_freedom(::MockProposal{T, D, TT}) where {T, D, TT} = D
 
 ### overwriting the generic because MockProposal is not random
 # TODO: adjust proposal interface, maybe use `generate_proposal!` as the interface

--- a/src/mocks/target.jl
+++ b/src/mocks/target.jl
@@ -1,14 +1,14 @@
-struct MockTarget <: GPUEventGenerators.AbstractTargetDistribution end
+struct MockTarget <: RejectionSamplers.AbstractTargetDistribution end
 
 
 function _mock_target(x::Real)
     return x < 0 ? zero(x) : one(x)
 end
 
-GPUEventGenerators._compute(::MockTarget, x::T) where {T <: Real} = _mock_target(x)
+RejectionSamplers._compute(::MockTarget, x::T) where {T <: Real} = _mock_target(x)
 
 # scalar
-function GPUEventGenerators._compute!(
+function RejectionSamplers._compute!(
         ::MockTarget,
         dest::AbstractArray{T},
         x::AbstractArray{TT}
@@ -25,10 +25,10 @@ function _mock_target(x::SVector{N, T}) where {N, T <: Real}
     return mapreduce(_mock_target, +, x)
 end
 
-GPUEventGenerators._compute(::MockTarget, x::SVector{N, T}) where {N, T <: Real} = _mock_target(x)
+RejectionSamplers._compute(::MockTarget, x::SVector{N, T}) where {N, T <: Real} = _mock_target(x)
 
 # NOTE: even if trivially the same as for scalars, this will stay to be optimized later
-function GPUEventGenerators._compute!(
+function RejectionSamplers._compute!(
         ::MockTarget,
         dest::AbstractArray{T},
         x::AbstractArray{TT}
@@ -47,9 +47,9 @@ function _mock_target(x::NTuple{N, T}) where {N, T <: Real}
     return mapreduce(_mock_target, +, x)
 end
 
-GPUEventGenerators._compute(::MockTarget, x::NTuple{N, T}) where {N, T <: Real} = _mock_target(x)
+RejectionSamplers._compute(::MockTarget, x::NTuple{N, T}) where {N, T <: Real} = _mock_target(x)
 
-function GPUEventGenerators._compute!(
+function RejectionSamplers._compute!(
         ::MockTarget,
         dest::AbstractArray{T},
         x::AbstractArray{TT}

--- a/test/generate.jl
+++ b/test/generate.jl
@@ -14,7 +14,7 @@ function testsuite_univariate_generation(backend, vec_type, el_type, N, batch_si
 
     EG = EventGenerator(dist, proposal, max_value; backend, in_type = el_type, out_type = el_type)
 
-    data = GPUEventGenerators.generate_events(
+    data = RejectionSamplers.generate_events(
         EG,
         N,
         batch_size,
@@ -48,7 +48,7 @@ function testsuite_multivariate_generation(backend, vec_type, el_type, N, batch_
 
         EG = EventGenerator(dist, proposal, max_value; backend, in_type = SVector{dim, el_type}, out_type = el_type)
 
-        data = GPUEventGenerators.generate_events(
+        data = RejectionSamplers.generate_events(
             EG,
             N,
             batch_size,
@@ -72,8 +72,8 @@ function testsuite_buffer_allocation(backend, in_type, out_type, batch_size, res
     EG = EventGenerator(target, proposal, max_val; backend, in_type, out_type)
 
     @testset "batch buffer" begin
-        buffer_direct = GPUEventGenerators._allocate_batch_buffer(backend, in_type, out_type, batch_size)
-        buffer_event_generator = GPUEventGenerators._allocate_batch_buffer(EG, batch_size)
+        buffer_direct = RejectionSamplers._allocate_batch_buffer(backend, in_type, out_type, batch_size)
+        buffer_event_generator = RejectionSamplers._allocate_batch_buffer(EG, batch_size)
 
         @testset "$buffer_name" for (buffer_name, buffer) in (
                 ("direct", buffer_direct),
@@ -95,8 +95,8 @@ function testsuite_buffer_allocation(backend, in_type, out_type, batch_size, res
     end
 
     @testset "output buffer" begin
-        buffer_direct = GPUEventGenerators._allocate_output_buffer(backend, in_type, out_type, batch_size, res_size)
-        buffer_event_generator = GPUEventGenerators._allocate_output_buffer(EG, batch_size, res_size)
+        buffer_direct = RejectionSamplers._allocate_output_buffer(backend, in_type, out_type, batch_size, res_size)
+        buffer_event_generator = RejectionSamplers._allocate_output_buffer(EG, batch_size, res_size)
 
         @testset "$buffer_name" for (buffer_name, buffer) in (
                 ("direct", buffer_direct),
@@ -131,9 +131,9 @@ function testsuite_proposal_stage(backend, vec_type, in_type, out_type, batch_si
 
     EG = EventGenerator(target, proposal, max_val; backend, in_type, out_type)
 
-    buffer = GPUEventGenerators._allocate_batch_buffer(EG, batch_size)
+    buffer = RejectionSamplers._allocate_batch_buffer(EG, batch_size)
 
-    GPUEventGenerators.generate_proposals!(EG, buffer)
+    RejectionSamplers.generate_proposals!(EG, buffer)
 
     # building groundtruth
     # NOTE: works, because the mock proposal is deterministic
@@ -163,16 +163,16 @@ function testsuite_target_stage(backend, vec_type, in_type, out_type, batch_size
 
     EG = EventGenerator(target, proposal, max_val; backend, in_type, out_type)
 
-    buffer = GPUEventGenerators._allocate_batch_buffer(EG, batch_size)
+    buffer = RejectionSamplers._allocate_batch_buffer(EG, batch_size)
 
-    GPUEventGenerators.generate_proposals!(EG, buffer)
+    RejectionSamplers.generate_proposals!(EG, buffer)
 
-    GPUEventGenerators.evaluate_target!(EG, buffer)
+    RejectionSamplers.evaluate_target!(EG, buffer)
 
 
     h_groundtruth = Vector{out_type}(undef, batch_size)
     d_groundtruth = vec_type(h_groundtruth)
-    GPUEventGenerators._compute!(target, d_groundtruth, buffer.args)
+    RejectionSamplers._compute!(target, d_groundtruth, buffer.args)
 
     @test isapprox(
         Vector(buffer.vals),
@@ -184,11 +184,11 @@ end
 
 #TODO: move these function to mocks/utils.jl
 
-function mock_make_invalid!(buffer::GPUEventGenerators.EventOutputBuffers{T, U}) where {T, U}
+function mock_make_invalid!(buffer::RejectionSamplers.EventOutputBuffers{T, U}) where {T, U}
     return fill!(buffer.vals, -one(U))
 end
 
-function mock_generate_probabilities(buffer::GPUEventGenerators.EventBatchBuffers{T, U}) where {T, U}
+function mock_generate_probabilities(buffer::RejectionSamplers.EventBatchBuffers{T, U}) where {T, U}
     return fill!(buffer.probs, U(0.5))
 end
 
@@ -206,17 +206,17 @@ function testsuite_filterscan_stage(backend, vec_type, in_type, out_type, batch_
 
     EG = EventGenerator(target, proposal, max_val; backend, in_type, out_type)
 
-    batch_buffer = GPUEventGenerators._allocate_batch_buffer(EG, batch_size)
+    batch_buffer = RejectionSamplers._allocate_batch_buffer(EG, batch_size)
 
-    GPUEventGenerators.generate_proposals!(EG, batch_buffer)
-    GPUEventGenerators.evaluate_target!(EG, batch_buffer)
+    RejectionSamplers.generate_proposals!(EG, batch_buffer)
+    RejectionSamplers.evaluate_target!(EG, batch_buffer)
     mock_generate_probabilities(batch_buffer)
 
-    output_buffer = GPUEventGenerators._allocate_output_buffer(EG, batch_size, res_size)
+    output_buffer = RejectionSamplers._allocate_output_buffer(EG, batch_size, res_size)
     mock_make_invalid!(output_buffer)
     no_accepted_groundtruth = mock_no_accepted(batch_size)
 
-    GPUEventGenerators.rejection_filter!(EG, batch_buffer, output_buffer)
+    RejectionSamplers.rejection_filter!(EG, batch_buffer, output_buffer)
 
 
     out_weights = Vector(output_buffer.vals)

--- a/test/max_finder.jl
+++ b/test/max_finder.jl
@@ -56,8 +56,8 @@ function testsuite_max_finder_gaussian(backend, vec_type, out_dtype, dim)
             if !(out_dtype == Float16)
                 # groundtruth
                 samples = Vector{SVector{dim, out_dtype}}(undef, n)
-                GPUEventGenerators._rand!(RNG, proposal, samples)
-                weights = sort(GPUEventGenerators._compute.(dist, samples))
+                RejectionSamplers._rand!(RNG, proposal, samples)
+                weights = sort(RejectionSamplers._compute.(dist, samples))
                 residual_weights = @. max(1, weights / max_val)
                 idx_last_unit_weight =
                     length(residual_weights) -

--- a/test/proposal.jl
+++ b/test/proposal.jl
@@ -18,11 +18,11 @@ function testsuite_uniform_proposal(backend, vec_type, el_type, N)
         @testset "reproducibility" begin
             d_payload1 = vec_type(zeros(el_type, N))
             d_payload2 = vec_type(zeros(el_type, N))
-            RNG = GPUEventGenerators.default_rng(typeof(d_payload1))
+            RNG = RejectionSamplers.default_rng(typeof(d_payload1))
             RNG2 = deepcopy(RNG)
 
-            GPUEventGenerators._rand!(RNG, u, d_payload1)
-            GPUEventGenerators._rand!(RNG, u, d_payload2)
+            RejectionSamplers._rand!(RNG, u, d_payload1)
+            RejectionSamplers._rand!(RNG, u, d_payload2)
 
             # FIXME: fix reproducibility for event generation
             @test_broken isapprox(Array(d_payload1), Array(d_payload2))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,11 +7,11 @@ using GPUArrays
 using KernelAbstractions
 using StaticArrays
 
-using GPUEventGenerators
-using GPUEventGenerators.TruncatedGaussians
-using GPUEventGenerators.PerturbativeCompton
-using GPUEventGenerators.TestUtils
-using GPUEventGenerators.Mocks
+using RejectionSamplers
+using RejectionSamplers.TruncatedGaussians
+using RejectionSamplers.PerturbativeCompton
+using RejectionSamplers.TestUtils
+using RejectionSamplers.Mocks
 
 SETUPS = TestSetup[]
 

--- a/test/target.jl
+++ b/test/target.jl
@@ -1,7 +1,7 @@
 RNG = Xoshiro(137137)
 
-struct TestUnivariateTarget <: GPUEventGenerators.AbstractUnivariatTargetDistribution end
-GPUEventGenerators._compute(::TestUnivariateTarget, x) = cos(x)
+struct TestUnivariateTarget <: RejectionSamplers.AbstractUnivariatTargetDistribution end
+RejectionSamplers._compute(::TestUnivariateTarget, x) = cos(x)
 
 const UNI_DIST = TestUnivariateTarget()
 
@@ -9,15 +9,15 @@ function testsuite_univariate_target(backend, vec_type, el_type, N)
     d_input = vec_type(rand(RNG, el_type, N))
     d_vals = similar(d_input)
 
-    h_groundtruth = GPUEventGenerators._compute.(UNI_DIST, Vector(d_input))
+    h_groundtruth = RejectionSamplers._compute.(UNI_DIST, Vector(d_input))
 
-    GPUEventGenerators._compute!(UNI_DIST, d_vals, d_input)
+    RejectionSamplers._compute!(UNI_DIST, d_vals, d_input)
 
     return @test isapprox(Vector(d_vals), h_groundtruth)
 end
 
-struct TestMultivariateTarget{S} <: GPUEventGenerators.AbstractMultivariateTarget{S} end
-GPUEventGenerators._compute(::TestMultivariateTarget, x) = cos(prod(x))
+struct TestMultivariateTarget{S} <: RejectionSamplers.AbstractMultivariateTarget{S} end
+RejectionSamplers._compute(::TestMultivariateTarget, x) = cos(prod(x))
 
 
 function testsuite_multivariate_target(backend, vec_type, el_type, N)
@@ -28,9 +28,9 @@ function testsuite_multivariate_target(backend, vec_type, el_type, N)
         d_input = vec_type(rand(RNG, SVector{dim, el_type}, N))
         d_vals = vec_type(rand(RNG, el_type, N))
 
-        h_groundtruth = GPUEventGenerators._compute.(MULT_DIST, Vector(d_input))
+        h_groundtruth = RejectionSamplers._compute.(MULT_DIST, Vector(d_input))
 
-        GPUEventGenerators._compute!(MULT_DIST, d_vals, d_input)
+        RejectionSamplers._compute!(MULT_DIST, d_vals, d_input)
 
         @test isapprox(Vector(d_vals), h_groundtruth)
     end
@@ -63,9 +63,9 @@ function testsuite_Compton_target(backend, vec_type, el_type, N)
 
         d_vals = vec_type(rand(RNG, el_type, N))
 
-        h_groundtruth = GPUEventGenerators._compute.(COMPTON_DIST, h_coords)
+        h_groundtruth = RejectionSamplers._compute.(COMPTON_DIST, h_coords)
 
-        GPUEventGenerators._compute!(COMPTON_DIST, d_vals, d_coords)
+        RejectionSamplers._compute!(COMPTON_DIST, d_vals, d_coords)
 
         @test isapprox(Vector(d_vals), h_groundtruth)
     end


### PR DESCRIPTION
With this PR, the package is rebranded to `RejectionSamplers.jl`. Locally, the unit tests pass and the docs can be built (by adding working versions of QEDbase and QEDcore using `add_dev.jl`). 

This solves #1 