### PR TITLE
Enable code coverage in the CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -11,6 +11,7 @@ generate_pipeline:
     CI_QED_ENABLE_CUDA_TESTS: "ON"
     CI_QED_ENABLE_AMDGPU_TESTS: "ON"
     CI_QED_ENABLE_INTEG_TESTS: "OFF"
+    CI_QED_IS_CODE_COVERAGE: "ON"
   script:
     - apt update && apt install -y git
     - git clone --depth 1 -b $CI_QED_GIT_CI_TOOLS_BRANCH $CI_QED_GIT_CI_TOOLS_URL /generator

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Doc Stable](https://img.shields.io/badge/docs-stable-blue.svg)](https://qedjl-project.github.io/RejectionSamplers.jl/stable)
 [![Doc Dev](https://img.shields.io/badge/docs-dev-blue.svg)](https://qedjl-project.github.io/RejectionSamplers.jl/dev)
 [![pipeline status](https://gitlab.com/hzdr/qedjl-project/RejectionSamplers-jl/badges/dev/pipeline.svg)](https://gitlab.com/hzdr/qedjl-project/RejectionSamplers-jl/-/commits/dev)
+[![codecov](https://codecov.io/gh/QEDjl-project/RejectionSamplers.jl/graph/badge.svg?token=46ATK29J1F)](https://codecov.io/gh/QEDjl-project/RejectionSamplers.jl)
 [![code style: runic](https://img.shields.io/badge/code_style-%E1%9A%B1%E1%9A%A2%E1%9A%BE%E1%9B%81%E1%9A%B2-black)](https://github.com/fredrikekre/Runic.jl)
 
 **RejectionSamplers.jl** provides a flexible, hardware-agnostic framework for implementing


### PR DESCRIPTION
To enable code coverage do the following steps.
1. Go to codecov.io and login with your Github account. Enable the project, got to configuration page of the project and copy the access token.
2. Go to the Gitlab.com mirror repository and navigate to `Settings->CI/CD`. Add the CI/CD variables with the name `CODECOV_TOKEN` and the copied token as value. Set the following properties:
<img width="382" height="388" alt="image" src="https://github.com/user-attachments/assets/4a4cabb0-f395-4032-b3b0-28679b22247c" />

3. Add the environment variable `CI_QED_IS_CODE_COVERAGE: "ON"` to the variable section of the generator job.
4. Add a codecov config file in the project root. Can be a empty file named `codecov.yml`.

# Note

The PRs #14 and #26 are only used for developing purpose and will be closed after merging this PR.

# ToDo
- [x] https://github.com/QEDjl-project/QuantumElectrodynamics.jl/pull/152 needs to merged first
- [x] use default branch instead test branch for bootloader.jl
- [x] add codecov.io badge