### PR TITLE
Add gpu arrays patch for rand!

### DIFF
--- a/src/RejectionSamplers.jl
+++ b/src/RejectionSamplers.jl
@@ -40,6 +40,7 @@ using StaticArrays
 using StaticArrays: sacollect
 using StructArrays
 
+include("patches/gpuarrays.jl")
 
 include("samples/interface.jl")
 include("samples/generic.jl")

--- a/src/patches/gpuarrays.jl
+++ b/src/patches/gpuarrays.jl
@@ -1,7 +1,3 @@
-# generic fallback to Random.rand! (used on CPU)
-_rand!(rng::AbstractRNG, a::Vector) = Random.rand!(rng, a)
-
-#=
 function gpu_rand(
         ::Type{TT},
         threadid,
@@ -11,11 +7,18 @@ function gpu_rand(
     return TT(ntuple(x -> GPUArrays.gpu_rand(T, threadid, randstate), N))
 end
 
-# TODO: is this necessary
-function _rand!(
+function gpu_rand(
+        ::Type{TT},
+        threadid,
+        randstate::AbstractVector{NTuple{4, UInt32}},
+    ) where {N, T, TT <: NTuple{N, T}}
+    return ntuple(x -> GPUArrays.gpu_rand(T, threadid, randstate), N)
+end
+
+function Random.rand!(
         rng::GPUArrays.RNG,
         A::GPUArrays.AnyGPUArray{TT},
-    ) where {T, N, TT <: SVector{N, T}}
+    ) where {T, N, TT <: Union{SVector{N, T}, NTuple{N, T}}}
     isempty(A) && return A
     @kernel function rand!(a, randstate)
         idx = @index(Global, Linear)
@@ -24,15 +27,3 @@ function _rand!(
     rand!(get_backend(A))(A, rng.state; ndrange = size(A))
     return A
 end
-=#
-
-"""
-
-    default_rng(v::AbstractVector)
-
-Return default rng to randomize given vector. Uses fallbacks on `Random.default_rng` and `GPUArrays.default_rng`.
-"""
-function default_rng end
-
-default_rng(::Type{T}) where {T} = Random.default_rng()
-default_rng(::Type{V}) where {V <: GPUArrays.AnyGPUArray} = GPUArrays.default_rng(V)

--- a/src/patches/gpuarrays.jl
+++ b/src/patches/gpuarrays.jl
@@ -1,3 +1,8 @@
+## rand! implementation for NTuple and SVector for GPUArrays.RNG
+# can be removed if added to GPUArrays or
+# https://github.com/JuliaGPU/AMDGPU.jl/issues/881
+# is solved.
+
 function gpu_rand(
         ::Type{TT},
         threadid,

--- a/src/proposal/random.jl
+++ b/src/proposal/random.jl
@@ -1,31 +1,6 @@
 # generic fallback to Random.rand! (used on CPU)
 _rand!(rng::AbstractRNG, a::Vector) = Random.rand!(rng, a)
 
-#=
-function gpu_rand(
-        ::Type{TT},
-        threadid,
-        randstate::AbstractVector{NTuple{4, UInt32}},
-    ) where {N, T, TT <: SVector{N, T}}
-    #return sacollect(TT, _ -> GPUArrays.gpu_rand(T, threadid, randstate))
-    return TT(ntuple(x -> GPUArrays.gpu_rand(T, threadid, randstate), N))
-end
-
-# TODO: is this necessary
-function _rand!(
-        rng::GPUArrays.RNG,
-        A::GPUArrays.AnyGPUArray{TT},
-    ) where {T, N, TT <: SVector{N, T}}
-    isempty(A) && return A
-    @kernel function rand!(a, randstate)
-        idx = @index(Global, Linear)
-        @inbounds a[idx] = gpu_rand(TT, ((idx - 1) % length(randstate) + 1), randstate)
-    end
-    rand!(get_backend(A))(A, rng.state; ndrange = size(A))
-    return A
-end
-=#
-
 """
 
     default_rng(v::AbstractVector)

--- a/test/patches/gpuarrays.jl
+++ b/test/patches/gpuarrays.jl
@@ -1,0 +1,17 @@
+function testsuite_gpuarrays_rand(backend, vec_type, val_type, size)
+
+    # these tests are GPU only
+    if backend isa CPU
+        return nothing
+    end
+
+    payload = allocate(backend, val_type, size)
+    payload_untouched = deepcopy(payload)
+
+    test_rng = GPUArrays.default_rng(vec_type)
+
+    rand!(test_rng, payload)
+
+    return @test !any(_isapprox.(Array(payload_untouched), Array(payload)))
+
+end

--- a/test/patches/gpuarrays.jl
+++ b/test/patches/gpuarrays.jl
@@ -12,6 +12,7 @@ function testsuite_gpuarrays_rand(backend, vec_type, val_type, size)
 
     rand!(test_rng, payload)
 
-    return @test !any(_isapprox.(Array(payload_untouched), Array(payload)))
+    @test !all(_isapprox.(Array(payload_untouched), Array(payload)))
 
+    return nothing
 end

--- a/test/patches/testsuite.jl
+++ b/test/patches/testsuite.jl
@@ -1,0 +1,18 @@
+include("gpuarrays.jl")
+
+if VERSION >= v"1.11"
+    _get_value_types(el_type, ::Val{N} = Val(4)) where {N} = (el_type, SVector{N, el_type}, NTuple{N, el_type})
+else
+    # Julia 1.10 does not support random generation of NTuple on CPU
+    @warn "Julia 1.10 does not support random generation of NTuple on CPU"
+    _get_value_types(el_type, ::Val{N} = Val(4)) where {N} = (el_type, SVector{N, el_type})
+end
+
+function testsuite_patches_run(backend, vec_type, el_type)
+
+    return @testset "val_type: $val_type" for val_type in _get_value_types(el_type)
+
+        @testset "GPUArrays.RNG rand!" testsuite_gpuarrays_rand(backend, vec_type, val_type, 256)
+
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -122,9 +122,17 @@ end
 
 
 include("testsuite.jl")
+include("patches/testsuite.jl")
 
 for stp in SETUPS
+
     @testset "$backend $vec_type $el_type" for (backend, vec_type, el_type) in combinations(stp)
         testsuite_run(backend, vec_type, el_type)
+    end
+
+    @testset "patches" begin
+        @testset "$backend $vec_type $el_type" for (backend, vec_type, el_type) in combinations(stp)
+            testsuite_patches_run(backend, vec_type, el_type)
+        end
     end
 end


### PR DESCRIPTION
- [x] This PR is based on #35 and should be considered for merging afterwards 

This adds `Random.rand!` implementations for `GPUArrays.RNG` and arrays of `NTuple` and `SVector`. 

This is a patch for `GPUArrays`, or the backend libraries, and should be removed once they implement similar functionality. 