### PR TITLE
Add transform based sampler

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,7 +4,6 @@ version = "0.1.1"
 authors = ["Uwe Hernandez Acosta <u.hernandez@hzdr.de>", "Simeon Ehrig", "Anton Reinhard", "René Widera"]
 
 [deps]
-AcceleratedKernels = "6a4ca0a5-0e36-4168-a932-d9be78d558f1"
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
 Atomix = "a9b6321e-bd34-4604-b9c9-b65b8de01458"
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
@@ -31,7 +30,6 @@ PlotEx = "StatsPlots"
 oneAPITestExt = "oneAPI"
 
 [compat]
-AcceleratedKernels = "0.4.3"
 Adapt = "4.4.0"
 Atomix = "1.1.1"
 Distributions = "0.25.119"

--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ version = "0.1.1"
 authors = ["Uwe Hernandez Acosta <u.hernandez@hzdr.de>", "Simeon Ehrig", "Anton Reinhard", "René Widera"]
 
 [deps]
+AcceleratedKernels = "6a4ca0a5-0e36-4168-a932-d9be78d558f1"
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
 Atomix = "a9b6321e-bd34-4604-b9c9-b65b8de01458"
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
@@ -30,6 +31,7 @@ PlotEx = "StatsPlots"
 oneAPITestExt = "oneAPI"
 
 [compat]
+AcceleratedKernels = "0.4.3"
 Adapt = "4.4.0"
 Atomix = "1.1.1"
 Distributions = "0.25.119"

--- a/src/RejectionSamplers.jl
+++ b/src/RejectionSamplers.jl
@@ -64,6 +64,7 @@ include("proposal/uniform.jl")
 
 include("sampler/interface.jl")
 include("sampler/random.jl")
+include("sampler/transform.jl")
 include("sampler/utils.jl")
 
 include("target.jl")

--- a/src/mocks/sampler.jl
+++ b/src/mocks/sampler.jl
@@ -2,10 +2,11 @@
 # - use the mock proposal and implement the new interface
 
 abstract type AbstractMockSampler{TT, T} <: RejectionSamplers.AbstractSampler{TT, T} end
+abstract type AbstractMockTransformbasedSampler{TT, T} <: RejectionSamplers.AbstractTransformBasedSampler{TT, T} end
 
 function RejectionSamplers.allocate_buffer(
         rng::AbstractRNG,
-        sampler::AbstractMockSampler{TT, T},
+        sampler::Union{AbstractMockSampler{TT, T}, AbstractMockTransformbasedSampler{TT, T}},
         backend::KernelAbstractions.Backend,
         size
     ) where {T, TT}
@@ -116,4 +117,74 @@ function RejectionSamplers._rand_single(rng::AbstractRNG, sampler::MockSamplerSi
         ntuple(x -> -one(T), Val(N)),
         sampler.weight
     )
+end
+
+### transform based sampler
+struct MockTransformBasedSampler{T, D, TT} <: AbstractMockTransformbasedSampler{TT, T}
+    weight::T
+
+    # scalar sample
+    MockTransformBasedSampler(::Type{T}, w::T) where {T <: Real} = new{T, 1, T}(w)
+
+    # SVector sample
+    MockTransformBasedSampler(::Type{TT}, w::T) where {N, T <: Real, TT <: SVector{N, T}} = new{T, N, TT}(w)
+
+    # NTuple sample
+    MockTransformBasedSampler(::Type{TT}, w::T) where {N, T <: Real, TT <: NTuple{N, T}} = new{T, N, TT}(w)
+end
+
+RejectionSamplers.degrees_of_freedom(::MockTransformBasedSampler{T, D, TT}) where {T, D, TT} = D
+
+@inline function RejectionSamplers._transform_value(
+        sampler::MockTransformBasedSampler{T, 1},
+        v::T,
+    ) where {T}
+    w = sampler.weight
+    return w
+end
+
+@inline function RejectionSamplers._transform_value(
+        sampler::MockTransformBasedSampler{T, N},
+        v::SVector{N, T},
+    ) where {N, T}
+    w = sampler.weight
+    return SVector{N, T}(
+        ntuple(
+            x -> w,
+            Val(N),
+        ),
+    )
+end
+
+
+@inline function RejectionSamplers._transform_value(
+        sampler::MockTransformBasedSampler{T, N},
+        v::NTuple{N, T},
+    ) where {N, T}
+    w = sampler.weight
+    return ntuple(x -> w, Val(N))
+end
+
+@inline function RejectionSamplers._transform_weight(
+        sampler::MockTransformBasedSampler{T},
+        v,
+        value::T
+    ) where {T}
+    return one(T)
+end
+
+@inline function RejectionSamplers._transform_weight(
+        sampler::MockTransformBasedSampler{T, N},
+        v,
+        value::NTuple{N, T}
+    ) where {T, N}
+    return one(T)
+end
+
+@inline function RejectionSamplers._transform_weight(
+        sampler::MockTransformBasedSampler{T, N},
+        v,
+        value::SVector{N, T}
+    ) where {T, N}
+    return one(T)
 end

--- a/src/mocks/utils.jl
+++ b/src/mocks/utils.jl
@@ -25,3 +25,24 @@ end
 groundtruth_sinlge_sample(::Type{VALTYPE}) where {VALTYPE <: Real} = -one(VALTYPE)
 groundtruth_sinlge_sample(::Type{VALTYPE}) where {T, N, VALTYPE <: SVector{N, T}} = .- ones(VALTYPE)
 groundtruth_sinlge_sample(::Type{VALTYPE}) where {T, N, VALTYPE <: NTuple{N, T}} = ntuple(x -> - one(T), Val(N))
+
+function groundtruth_transformbased_samples(::Type{T}, sampler, size) where {T <: Real}
+    return SampleBuffer(
+        fill(sampler.weight, size),
+        ones(T, size)
+    )
+end
+
+function groundtruth_transformbased_samples(::Type{VALTYPE}, sampler, size) where {T, N, VALTYPE <: SVector{N, T}}
+    return SampleBuffer(
+        fill(SVector{N, T}(ntuple(j -> sampler.weight, Val(N))), size),
+        ones(T, size)
+    )
+end
+
+function groundtruth_transformbased_samples(::Type{VALTYPE}, sampler, size) where {T, N, VALTYPE <: NTuple{N, T}}
+    return SampleBuffer(
+        fill(ntuple(j -> sampler.weight, Val(N)), size),
+        ones(T, size)
+    )
+end

--- a/src/sampler/interface.jl
+++ b/src/sampler/interface.jl
@@ -45,6 +45,8 @@ to enable more efficient or more specialized sampling strategies:
 """
 abstract type AbstractSampler{Ts, Tw} end
 
+Base.broadcastable(s::AbstractSampler) = Ref(s)
+
 """
     _rand_from_host!(host_side_rng, sampler, backend, buf)
 

--- a/src/sampler/random.jl
+++ b/src/sampler/random.jl
@@ -72,8 +72,8 @@ function _rand_from_device!(
         buf::AbstractSampleBuffer,
     )
     _rand_gpu_kernel(backend, 32)(
-        rng, samples, sampler;
-        ndrange = size(samples)
+        rng, sampler, buf;
+        ndrange = length(buf)
     )
     return nothing
 end

--- a/src/sampler/transform.jl
+++ b/src/sampler/transform.jl
@@ -1,0 +1,56 @@
+abstract type AbstractTransformBasedSampler{Tv, Tw} <: AbstractSampler{Tv, Tw} end
+
+
+"""
+    _transform_value(sampler::AbstractTransformBasedSampler{Tv, Tw}, unit_input)
+
+Interface function: transform unit random numbers into the target sample space.
+Return the transformed value.
+"""
+function _transform_value end
+
+"""
+    _transform_weight(sampler::AbstractTransformBasedSampler{Tv, Tw}, unit_input, value)
+
+Interface function: return weight for the transformation [`_transform_value`](@ref) for given `unit_input` and `value` in sample space.
+"""
+function _transform_weight end
+
+"""
+    _transform!(sampler::AbstractTransformBasedSampler{Tv, Tw}, buffer, unit_rng_nums)
+        -> nothing
+
+Batch version of [`transform`](@ref).
+"""
+function _transform!(sampler::AbstractTransformBasedSampler, buf, vs)
+    buf.samples.value .= _transform_value.(sampler, vs)
+    buf.samples.weight .= _transform_weight.(sampler, vs, buf.samples.value)
+
+    return nothing
+end
+
+
+# device-side RNG can transform every sample directly
+function _rand_single(rng::AbstractRNG, sampler::AbstractTransformBasedSampler{Tv}) where {Tv}
+    u = rand(rng, Tv)
+    value = _transform_value(sampler, u)
+    weight = _transform_weight(sampler, u, value)
+    return Sample(value, weight)
+end
+
+
+function _rand_from_host!(
+        rng::AbstractRNG,
+        sampler::AbstractTransformBasedSampler{Tv, Tw},
+        backend::KernelAbstractions.Backend,
+        buf::AbstractSampleBuffer
+    ) where {Tv, Tw}
+    N = degrees_of_freedom(sampler)
+
+    rnd_nums = allocate(backend, Tv, length(buf))
+    rand!(rng, rnd_nums)
+
+    _transform!(sampler, buf, rnd_nums)
+
+    return nothing
+end

--- a/test/sampler.jl
+++ b/test/sampler.jl
@@ -86,3 +86,89 @@ function testsuite_abstract_sampler(backend, vec_type, val_type, w_type, batch_s
     end
     return nothing
 end
+
+function testsuite_transformbased_sampler(backend, vec_type, val_type, w_type, batch_size)
+    @testset "properties" begin
+        test_weight = rand(PARAMETER_RNG, w_type)
+        test_sampler = Mocks.MockTransformBasedSampler(val_type, test_weight)
+
+        @test value_type(test_sampler) == val_type
+        @test weight_type(test_sampler) == w_type
+    end
+    @testset "host side rng" begin
+        @testset "rng: $(typeof(rng))" for rng in TestUtils.get_host_rngs(backend)
+
+            @testset "buffer allocation" begin
+                test_weight = rand(PARAMETER_RNG, w_type)
+                test_sampler = Mocks.MockTransformBasedSampler(val_type, test_weight)
+
+                test_buffer = allocate_buffer(rng, test_sampler, backend, batch_size)
+
+                @test test_buffer isa SampleBuffer
+
+                @test get_backend(test_buffer) isa typeof(backend)
+                @test length(test_buffer) == batch_size
+                @test eltype(test_buffer) == Sample{val_type, w_type}
+                @test value_type(test_buffer) == val_type
+                @test weight_type(test_buffer) == w_type
+
+                @test value_type(test_buffer) == value_type(test_sampler)
+                @test weight_type(test_buffer) == weight_type(test_sampler)
+            end
+
+            @testset "sampling" begin
+                test_weight = rand(PARAMETER_RNG, w_type)
+                test_sampler = Mocks.MockTransformBasedSampler(val_type, test_weight)
+
+                groundtruth = Mocks.groundtruth_transformbased_samples(val_type, test_sampler, batch_size)
+                test_buffer = allocate_buffer(rng, test_sampler, backend, batch_size)
+
+                rand!(rng, test_sampler, backend, test_buffer)
+
+                # TODO: use getvalues and getweights after they are tested
+                @test _isapprox(Array(test_buffer.samples.value), groundtruth.samples.value)
+                @test _isapprox(Array(test_buffer.samples.weight), groundtruth.samples.weight)
+            end
+        end
+    end
+    @testset "device side rng" begin
+        @testset "rng: $(typeof(rng))" for rng in TestUtils.get_device_rngs(backend)
+
+            @testset "buffer allocation" begin
+                test_weight = rand(PARAMETER_RNG, w_type)
+                test_sampler = Mocks.MockTransformBasedSampler(val_type, test_weight)
+
+                test_buffer = allocate_buffer(rng, test_sampler, backend, batch_size)
+
+                @test test_buffer isa SampleBuffer
+
+                @test get_backend(test_buffer) isa typeof(backend)
+                @test length(test_buffer) == batch_size
+                @test eltype(test_buffer) == Sample{val_type, w_type}
+                @test value_type(test_buffer) == val_type
+                @test weight_type(test_buffer) == w_type
+
+                @test value_type(test_buffer) == value_type(test_sampler)
+                @test weight_type(test_buffer) == weight_type(test_sampler)
+            end
+
+            @testset "batch sample" begin
+                test_weight = rand(PARAMETER_RNG, w_type)
+                test_sampler = Mocks.MockTransformBasedSampler(val_type, test_weight)
+
+                groundtruth = Mocks.groundtruth_transformbased_samples(val_type, test_sampler, batch_size)
+                test_buffer = allocate_buffer(rng, test_sampler, backend, batch_size)
+
+                rand!(rng, test_sampler, backend, test_buffer)
+
+                # TODO: use getvalues and getweights after they are tested
+                @test _isapprox(Array(test_buffer.samples.value), groundtruth.samples.value)
+                @test _isapprox(Array(test_buffer.samples.weight), groundtruth.samples.weight)
+            end
+            @testset "single sample" begin
+
+            end
+        end
+    end
+    return nothing
+end

--- a/test/testsuite.jl
+++ b/test/testsuite.jl
@@ -52,6 +52,14 @@ function testsuite_run(backend, vec_type, el_type)
             el_type,
             256
         )
+
+        @testset "sampler" testsuite_transformbased_sampler(
+            backend,
+            vec_type,
+            val_type,
+            el_type,
+            256
+        )
     end
 
     @testset "filter scan" testsuite_filter_scan(


### PR DESCRIPTION
This PR adds an abstract sampler that operates by transforming random numbers into the sample space.

In this PR, this is based on two interface functions transforming values and weights 

```Julia
_transform_value(sampler,random_number)
_transform_weight(sampler, random_number, sample) 
```
Where `random_number` is a number, but also an `SVector` or `NTuple`. 

To implement this in place, this PR introduces 
```Julia
_transform!(sampler, buffer, random_number_vector)
```
where `buffer` is a `SampleBuffer`.

The Interface is tested using a mock sampler `MockTransformbasedSampler`, which transforms every random number into a sample filled with a given number and the weight of one. 